### PR TITLE
Update ubnt_get_wireguard.sh to use current fork

### DIFF
--- a/get_wireguard.sh
+++ b/get_wireguard.sh
@@ -130,7 +130,7 @@ info "Installed WireGuard version: $INSTALLED_VERSION"
 
 # Get list of releases
 GITHUB_API='https://api.github.com'
-GITHUB_REPO='Lochnair/vyatta-wireguard'
+GITHUB_REPO='FossoresLP/vyatta-wireguard'
 GITHUB_RELEASES_URL="${GITHUB_API}/repos/${GITHUB_REPO}/releases"
 GITHUB_RELEASES=$(curl --silent $GITHUB_RELEASES_URL)
 


### PR DESCRIPTION
https://github.com/FossoresLP/vyatta-wireguard is the currently maintained fork.